### PR TITLE
Update default github username to wpmobilebot

### DIFF
--- a/lib/submodule_update_flow.rb
+++ b/lib/submodule_update_flow.rb
@@ -40,7 +40,7 @@ class SubmoduleUpdateFlow
   def prs_to_close
     candidate_prs_to_close.filter do |_, pr|
       has_other_commits = @client_repo.pull_commits(pr.number).any? do |commit|
-        commit.author.login != 'wpversionupdatebot'
+        commit.author.login != 'wpmobilebot'
       end
       puts "PR ##{pr.number} has commits by other developers, skipping.." if has_other_commits
       !has_other_commits


### PR DESCRIPTION
We should fetch the username from remote, but we are currently experiencing rate limiting, so I wanted to go with the hard-coded value for now. Once v1 is working as expected, we can go back and fix this properly.