### PR TITLE
Propagate environment variables to Docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,3 +20,8 @@ steps:
     plugins:
       - docker#v3.8.0:
           image: "ruby:2.7.4"
+          propagate-environment: true
+          environment:
+            # DO NOT MANUALLY SET THIS VALUE!
+            # It is passed from the Buildkite agent to the Docker container
+            - "VERSION_TOOLKIT_GITHUB_TOKEN"


### PR DESCRIPTION
Sync jobs are currently failing because the `VERSION_TOOLKIT_GITHUB_TOKEN` environment variable is not passed to the Docker image, so the GitHub requests are not authenticated. This PR should fix the issue.